### PR TITLE
linux-pine64: remove vfat.scc from kernel features 

### DIFF
--- a/recipes-kernel/linux/linux-pine64_5.10.bb
+++ b/recipes-kernel/linux/linux-pine64_5.10.bb
@@ -33,3 +33,5 @@ KCONFIG_MODE="--alldefconfig"
 
 COMPATIBLE_MACHINE = "pine-a64-lts|sopine-a64"
 
+# This is necessary since kmeta would be necessary otherwise
+KERNEL_FEATURES_remove = "cfg/fs/vfat.scc"


### PR DESCRIPTION
This is necessary as from Yocto hardknott if "vfat" is included
in the machine features it's also checked that it is enabled in
the kernel features, using an scc file which comes from the
yocto-kernel-cache repository.